### PR TITLE
add a flag for using the default tags

### DIFF
--- a/examples/app.rb
+++ b/examples/app.rb
@@ -8,7 +8,7 @@ class App < Sinatra::Base
 
   sensible_logging(
     logger: Logger.new(STDOUT),
-    log_tags: TaggedLogger.default_tags + [lambda { |req| [req.port] }],
+    log_tags: [lambda { |req| [req.port] }],
     exclude_params: ['two']
   )
 

--- a/lib/sensible_logging.rb
+++ b/lib/sensible_logging.rb
@@ -6,9 +6,15 @@ require_relative './sensible_logging/middlewares/request_logger'
 
 module Sinatra
   module SensibleLogging
-    def sensible_logging(logger:, log_tags: [], exclude_params: [], tld_length: 1)
+    def sensible_logging(
+      logger:,
+      log_tags: [],
+      use_default_log_tags: true,
+      exclude_params: [],
+      tld_length: 1
+    )
       use RequestId
-      use TaggedLogger, logger, log_tags, tld_length
+      use TaggedLogger, logger, log_tags, use_default_log_tags, tld_length
       use RequestLogger, exclude_params
 
       before do

--- a/spec/middlewares/tagged_logger_spec.rb
+++ b/spec/middlewares/tagged_logger_spec.rb
@@ -18,24 +18,37 @@ describe TaggedLogger do
   let(:log_output) { StringIO.new }
   let(:logger) { Logger.new(log_output) }
   let(:dummy_app) { DummyApp.new(app) }
+  let(:tags) { [] }
+  let(:use_default_tags) { true }
+  let(:tld_length) { 1 }
+
+  subject { described_class.new(dummy_app, logger, tags, use_default_tags, tld_length) }
 
   it 'assigns the logger to env' do
     env = Rack::MockRequest.env_for('http://www.blah.google.co.uk/path')
     env['request_id'] = '123ABC'
-
-    described_class.new(dummy_app, logger, [], true, 2).call(env)
+    subject.call(env)
 
     expect(env['logger']).to_not eq(nil)
-    expect(log_output.string).to eq("[www.blah] [#{ENV['RACK_ENV']}] [123ABC] hello\n")
   end
 
   it 'works with non-subdomain hosts' do
     env = Rack::MockRequest.env_for('http://google.com/path')
     env['request_id'] = '123ABC'
-
-    described_class.new(dummy_app, logger, [], true).call(env)
+    subject.call(env)
 
     expect(env['logger']).to_not eq(nil)
     expect(log_output.string).to eq("[n/a] [#{ENV['RACK_ENV']}] [123ABC] hello\n")
+  end
+
+  context 'with nested subdomains' do
+    let(:tld_length) { 2 }
+
+    it 'logs 2 subdomains deep' do
+      env = Rack::MockRequest.env_for('http://www.blah.google.co.uk/path')
+      env['request_id'] = '123ABC'
+      subject.call(env)
+      expect(log_output.string).to eq("[www.blah] [#{ENV['RACK_ENV']}] [123ABC] hello\n")
+    end
   end
 end

--- a/spec/middlewares/tagged_logger_spec.rb
+++ b/spec/middlewares/tagged_logger_spec.rb
@@ -23,7 +23,7 @@ describe TaggedLogger do
     env = Rack::MockRequest.env_for('http://www.blah.google.co.uk/path')
     env['request_id'] = '123ABC'
 
-    described_class.new(dummy_app, logger, [], 2).call(env)
+    described_class.new(dummy_app, logger, [], true, 2).call(env)
 
     expect(env['logger']).to_not eq(nil)
     expect(log_output.string).to eq("[www.blah] [#{ENV['RACK_ENV']}] [123ABC] hello\n")
@@ -33,7 +33,7 @@ describe TaggedLogger do
     env = Rack::MockRequest.env_for('http://google.com/path')
     env['request_id'] = '123ABC'
 
-    described_class.new(dummy_app, logger, []).call(env)
+    described_class.new(dummy_app, logger, [], true).call(env)
 
     expect(env['logger']).to_not eq(nil)
     expect(log_output.string).to eq("[n/a] [#{ENV['RACK_ENV']}] [123ABC] hello\n")


### PR DESCRIPTION
This simplifies configuration so the app isn't exposed to taggedLogger anymore