### PR TITLE
CircleCI: Gems don't have a Gemfile.lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,16 +9,7 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "Gemfile.lock" }}
-
       - run: bundle install --jobs=4 --retry=3 --path vendor/bundle
-
-      - save_cache:
-          paths:
-            - ./vendor/bundle
-          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
 
       - run: bundle exec rspec --backtrace
 


### PR DESCRIPTION
With no `Gemfile.lock` we can't have a gem cache for CircleCI builds. We also want the gem to always be building against the latest versions of dependencies so we know if something breaks.