### PR TITLE
Logger will default to standard Ruby logger and to STDOUT

### DIFF
--- a/lib/sensible_logging.rb
+++ b/lib/sensible_logging.rb
@@ -7,7 +7,7 @@ require_relative './sensible_logging/middlewares/request_logger'
 module Sinatra
   module SensibleLogging
     def sensible_logging(
-      logger:,
+      logger: Logger.new(STDOUT),
       log_tags: [],
       use_default_log_tags: true,
       exclude_params: [],


### PR DESCRIPTION
This is probably the most likely use, so might as well have it as the default.