### PR TITLE
Add in the clients request IP to the request log

### DIFF
--- a/lib/sensible_logging/middlewares/request_logger.rb
+++ b/lib/sensible_logging/middlewares/request_logger.rb
@@ -12,7 +12,9 @@ class RequestLogger
     status, headers, body = @app.call(env)
     end_time = Time.now - start_time
 
-    message = "method=#{req.request_method} path=#{req.path} status=#{status} duration=#{end_time}"
+    client_ip = req.ip || 'n/a'
+
+    message = "method=#{req.request_method} path=#{req.path} client=#{client_ip} status=#{status} duration=#{end_time}"
     filtered_params = filter_params(req)
     message += " params=#{filtered_params}" if req.get? && ! filtered_params.empty?
     env['logger'].info(message)

--- a/spec/middlewares/request_logger_spec.rb
+++ b/spec/middlewares/request_logger_spec.rb
@@ -15,16 +15,25 @@ describe RequestLogger do
 
     described_class.new(app).call(env)
 
-    expect(logger).to have_received(:info).with('method=GET path=/test status=200 duration=1')
+    expect(logger).to have_received(:info).with('method=GET path=/test client=n/a status=200 duration=1')
   end
 
-  it 'logs the request and filters any excluded params' do
-    env = Rack::MockRequest.env_for('http://localhost/test?one=two&three=four')
+  it 'logs the request with REMOTE_ADDR' do
+    env = Rack::MockRequest.env_for('http://localhost/test', { 'REMOTE_ADDR' => '123.456.789.123' })
     env['logger'] = logger
 
-    described_class.new(app, ['one']).call(env)
+    described_class.new(app).call(env)
 
-    expect(logger).to have_received(:info).with('method=GET path=/test status=200 duration=1 params={"three"=>"four"}')
+    expect(logger).to have_received(:info).with('method=GET path=/test client=123.456.789.123 status=200 duration=1')
+  end
+
+  it 'logs the request with X_FORWARDED_FOR' do
+    env = Rack::MockRequest.env_for('http://localhost/test', { 'HTTP_X_FORWARDED_FOR' => '123.456.789.123' })
+    env['logger'] = logger
+
+    described_class.new(app).call(env)
+
+    expect(logger).to have_received(:info).with('method=GET path=/test client=123.456.789.123 status=200 duration=1')
   end
 
   it 'logs the request with no params if not GET' do
@@ -33,7 +42,7 @@ describe RequestLogger do
 
     described_class.new(app).call(env)
 
-    expect(logger).to have_received(:info).with('method=POST path=/test status=200 duration=1')
+    expect(logger).to have_received(:info).with('method=POST path=/test client=n/a status=200 duration=1')
   end
 
   after do


### PR DESCRIPTION
Closes #20 

Will either take the REMOTE_ADDR or forwarded IP address if behind a load balancer and include this in the request log line.