### PR TITLE
v0.4.0

### DIFF
--- a/lib/sensible_logging/version.rb
+++ b/lib/sensible_logging/version.rb
@@ -1,3 +1,3 @@
 module SensibleLogging
-  VERSION = "0.3.0"
+  VERSION = '0.4.0'
 end


### PR DESCRIPTION
* Defaults logger option to Ruby logger to STDOUT
* README more readble
* Include client request IP in request logger
* If host is an IP address, use that instead of subdomain