### PR TITLE
Override and disable Rack::CommonLogger

### DIFF
--- a/examples/config.ru
+++ b/examples/config.ru
@@ -1,4 +1,3 @@
-#\ --quiet
 require_relative './app'
 
 run App

--- a/lib/sensible_logging.rb
+++ b/lib/sensible_logging.rb
@@ -4,6 +4,14 @@ require_relative './sensible_logging/middlewares/request_id'
 require_relative './sensible_logging/middlewares/tagged_logger'
 require_relative './sensible_logging/middlewares/request_logger'
 
+module Rack
+  class CommonLogger
+    def call(env)
+      @app.call(env)
+    end
+  end
+end
+
 module Sinatra
   module SensibleLogging
     def sensible_logging(


### PR DESCRIPTION
Removes the need to add `#\ --quiet` flag into `config.ru` for each 
project that uses this.

After a lot of Googling, and looking at the various server handlers, this seems to be the only proven way to get this disabled unfortunately. 

Resolves #24 