### PR TITLE
Include log level severity tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ A logging library with sensible defaults for Sinatra apps.
   * duration
   * params if a `GET` request
 * Tagged logging, with some sensible defaults:
+  * severity
   * subdomain
   * environment
   * unique request ID
@@ -45,13 +46,15 @@ There are a number of options that you can pass into `sensible_logging`:
 * `logger`: The logging object.  
   **Default**: `Logger.new(STDOUT)`
 * `use_default_log_tags`: Includes the subdomain, `RACK_ENV` and unique request ID in the log tags.  
-  **Default**: `true` 
+  **Default**: `true`
 * `tld_length`: For example, if your domain was `www.google.com` this would result in `www` being tagged as your subdomain. If your domain is `www.google.co.uk`, set this value to `2` to correctly identify the subdomain as `www` rather than `www.google`.  
   **Default**: `1`.
 * `log_tags`: An array of additional log tags to include. This can be strings, or you can include a `lambda` that will be evaluated. The `lambda` is passed a Rack `Request` object, and it must return an array of string values.  
   **Default**: `[]`
 * `exclude_params`: An array of parameter names to be excluded from `GET` requests. By default, `GET` parameters are outputted in logs. If for example with the request `http://google.com/?one=dog&two=cat` you didn't want the `one` logged, you would set `exclude_params` to be `['one']`  
   **Default**: `[]`
+* `include_log_severity`: Includes the log severity in the tagged output, such as `INFO`, `DEBUG` etc  
+  **Default**: `true`
 
 ## Examples
 

--- a/lib/sensible_logging.rb
+++ b/lib/sensible_logging.rb
@@ -19,12 +19,22 @@ end
 module Sinatra
   # Sensible logging library for Sinatra based Apps
   module SensibleLogging
-    def sensible_logging(
-      opts
+    def sensible_logging( # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
+      logger: Logger.new(STDOUT),
+      log_tags: [],
+      use_default_log_tags: true,
+      exclude_params: [],
+      tld_length: 1,
+      include_log_severity: true
     )
-      options = default_options(opts)
-
-      setup_middlewares(options)
+      setup_middlewares(
+        logger: logger,
+        log_tags: log_tags,
+        use_default_log_tags: use_default_log_tags,
+        exclude_params: exclude_params,
+        tld_length: tld_length,
+        include_log_severity: include_log_severity
+      )
 
       before do
         env['rack.errors'] = env['rack.logger'] = env['logger']
@@ -34,28 +44,24 @@ module Sinatra
 
     private
 
-    def setup_middlewares(options)
+    def setup_middlewares( # rubocop:disable Metrics/ParameterLists
+      logger:,
+      log_tags:,
+      use_default_log_tags:,
+      exclude_params:,
+      tld_length:,
+      include_log_severity:
+    )
       use RequestId
       use(
         TaggedLogger,
-        logger: options[:logger],
-        tags: options[:log_tags],
-        use_default_log_tags: options[:use_default_log_tags],
-        tld_length: options[:tld_length],
-        include_log_severity: options[:include_log_severity]
+        logger: logger,
+        tags: log_tags,
+        use_default_tags: use_default_log_tags,
+        tld_length: tld_length,
+        include_log_severity: include_log_severity
       )
-      use RequestLogger, options[:exclude_params]
-    end
-
-    def default_options(opts)
-      {
-        logger: Logger.new(STDOUT),
-        log_tags: [],
-        use_default_log_tags: true,
-        exclude_params: [],
-        tld_length: 1,
-        include_log_severity: true
-      }.merge(opts)
+      use RequestLogger, exclude_params
     end
   end
 

--- a/lib/sensible_logging/middlewares/tagged_logger.rb
+++ b/lib/sensible_logging/middlewares/tagged_logger.rb
@@ -10,7 +10,7 @@ class TaggedLogger
     app,
     logger: Logger.new(STDOUT),
     tags: [],
-    use_default_tags: true,
+    use_default_tags: true, 
     tld_length: 1,
     include_log_severity: true
   )
@@ -34,10 +34,10 @@ class TaggedLogger
   private
 
   def setup_severity_tag(logger)
-    logger.formatter = proc do |severity, _datetime, _progname, msg|
-      "[#{severity}] #{msg}\n"
+    original_formatter = logger.formatter || ActiveSupport::Logger::SimpleFormatter.new
+    logger.formatter = proc do |severity, *args|
+      "[#{severity}] #{original_formatter.call(severity, *args)}"
     end
-
     logger
   end
 

--- a/lib/sensible_logging/middlewares/tagged_logger.rb
+++ b/lib/sensible_logging/middlewares/tagged_logger.rb
@@ -10,7 +10,7 @@ class TaggedLogger
     app,
     logger: Logger.new(STDOUT),
     tags: [],
-    use_default_tags: true, 
+    use_default_tags: true,
     tld_length: 1,
     include_log_severity: true
   )


### PR DESCRIPTION
Add log severity to tagged output, and include option to disable. Defaults to `true`.

Resolves #28 